### PR TITLE
Make improvements to authentication

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -52,11 +52,11 @@
   },
 
   //Group permission configuration. Matches made using https://github.com/jonschlinkert/micromatch
-  //All logged-out users are automatically part of the @unauthorized group.
-  //All logged-in users are automatically part of the @authorized group.
+  //All logged-out users are automatically part of the @authenticated group.
+  //All logged-in users are automatically part of the @unauthenticated group.
   "permissions": {
-    "@unauthorized": ["auth.*", "ping"],
-    "@authorized": ["*"]
+    "@authenticated": ["auth.*", "ping"],
+    "@unauthenticated": ["*"]
   }
 
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -53,7 +53,7 @@ Set-Cookie: token=<authorization_token>
 ```
 
 The request might also fail, and the response will have code `400` in case the
-request was invalid (like invalid data format), or `403` if the credentials are
+request was invalid (like invalid data format), or `401` if the credentials are
 invalid (eg. a wrong password or non-existent username).
 
 #### `GET /auth`
@@ -70,23 +70,16 @@ Authorization: Bearer: <authorization_token>
 200 OK
 -----
 {
-  "authorized": false,
-  "groups": ["@unauthorized"],
-  "permissions": ["auth.*", "ping"],
-  "session": {
-    "name": "TokenExpiredError",
-    "message": "Token expired"
-  }
+  "authenticated": false,
+  "reason": {"name": "TokenExpiredError", "message": "Token expired"}
 }
 ```
 
-The response JSON has the following structure:
-
-* `authorized`: A Boolean indicating whether the request would be authorized.
-* `groups`: An Array of groups that the token-holder is a member of.
-* `permissions`: An Array of permissions that the token-holder was granted.
-* `session`: Will be an Object with a `name` and `message` describing what went
-  wrong if `authorized` is `false`; or the Username if `authorized` is `true`.
+The response JSON contains an "authenticated" boolean, indicating whether the
+token proves authentication. In cases where the user is not authenticated a
+`reason` field will be present with an error explaining what went wrong. If the
+user *is* authenticated, then a `session` field will be present containing the
+token payload, for your convenience.
 
 Errors can be one of:
 
@@ -126,6 +119,7 @@ with a `token=`-field. The cookie only works for GET requests, and is intended
 to be a fall-back for when a resource is embedded inside an HTML page.
 
 When you are unauthorized to perform a certain requests, the response will
-always have status code `403`, and contain a message about the permission you
-are missing. To determine why a token might not have given you this permission,
-use [`GET /auth`](#get-auth).
+have status code `400` if you provided an invalid token, status code `401` if
+your token does not authenticate you or `403` if you are authenticated but
+missing the required permissions. The possible error names in the JSON response
+are equal to those you get from requesting [`GET /auth`](#get-auth).

--- a/src/actions/auth/_util.js
+++ b/src/actions/auth/_util.js
@@ -55,13 +55,13 @@ const invalidSessionType = error(500, {
 });
 
 //    missingAuthorizationHeader :: NotAuthorizedError
-const missingAuthorizationHeader = error(403, {
+const missingAuthorizationHeader = error(401, {
   name: 'MissingAuthorizationHeaderError',
   message: 'Missing Authorization header'
 });
 
 //    missingTokenCookie :: NotAuthorizedError
-const missingTokenCookie = error(403, {
+const missingTokenCookie = error(401, {
   name: 'MissingTokenCookieError',
   message: 'Missing Cookie header'
 });
@@ -79,13 +79,13 @@ const invalidAuthorizationHeader = error(400, {
 });
 
 //    tokenExpired :: NotAuthorizedError
-const tokenExpired = error(403, {
+const tokenExpired = error(401, {
   name: 'TokenExpiredError',
   message: 'Token expired'
 });
 
 //    refreshExpired :: NotAuthorizedError
-const refreshExpired = error(403, {
+const refreshExpired = error(401, {
   name: 'RefreshExpiredError',
   message: 'Token expired'
 });

--- a/src/actions/auth/create.js
+++ b/src/actions/auth/create.js
@@ -12,7 +12,7 @@ const {chain} = require('ramda');
 const config = require('config');
 
 //    invalidCredentials :: NotAuthorizedError
-const invalidCredentials = error(403, 'Invalid credentials');
+const invalidCredentials = error(401, 'Invalid credentials');
 
 //verify :: (String, String) -> Future Error True
 const verify = (pass, hash) => Future.node(done => bcrypt.compare(pass, hash, done));

--- a/src/actions/auth/index.js
+++ b/src/actions/auth/index.js
@@ -5,17 +5,7 @@ const {either} = require('sanctuary');
 const {errorToJson} = require('../../util/common');
 
 module.exports = req => Future.of(either(
-  error => ({
-    authorized: false,
-    session: errorToJson(error),
-    groups: req.auth.groups,
-    permissions: req.auth.permissions
-  }),
-  session => ({
-    authorized: true,
-    session: session.user,
-    groups: req.auth.groups,
-    permissions: req.auth.permissions
-  }),
+  error => ({authenticated: false, reason: errorToJson(error)}),
+  session => ({authenticated: true, session}),
   req.auth.session
 ));

--- a/src/actions/auth/session.js
+++ b/src/actions/auth/session.js
@@ -8,11 +8,11 @@ const error = require('http-errors');
 const mm = require('micromatch');
 const {getTokenFromRequest, tokenToSession} = require('./_util');
 
-//    authorizedGroups :: Array Group
-const authorizedGroups = ['@authorized'];
+//    authenticatedGroups :: Array Group
+const authenticatedGroups = ['@authenticated'];
 
-//    unauthorizedGroups :: Array Group
-const unauthorizedGroups = ['@unauthorized'];
+//    unauthenticatedGroups :: Array Group
+const unauthenticatedGroups = ['@unauthenticated'];
 
 //    missingPermission :: String -> NotAuthorizedError
 const missingPermission = x => error(403, `You are missing the ${x} permission`);
@@ -20,11 +20,11 @@ const missingPermission = x => error(403, `You are missing the ${x} permission`)
 //    getUserGroups :: User -> Array Group
 const getUserGroups = pipe([
   get(Array, 'groups'),
-  maybe(authorizedGroups, concat(authorizedGroups))
+  maybe(authenticatedGroups, concat(authenticatedGroups))
 ]);
 
 //    getUserGroupsFromSession :: Either Error Session -> Array Group
-const getUserGroupsFromSession = either(K(unauthorizedGroups), getUserGroups);
+const getUserGroupsFromSession = either(K(unauthenticatedGroups), getUserGroups);
 
 //    groupsToPermissions :: Array Group -> Array String
 const groupsToPermissions = chain(group => permissions[group] || []);

--- a/src/util/permission.js
+++ b/src/util/permission.js
@@ -1,7 +1,15 @@
 'use strict';
 
 const error = require('http-errors');
-const missingPermission = x => error(403, `You are missing the ${x} permission`);
+const {I, either} = require('sanctuary-env');
+const debug = require('debug')('util.permission');
+
+const missingPermission = error(403, `You are not authorized`);
 
 module.exports = required => (req, res, next) =>
-  req.auth.has(required) ? next() : next(missingPermission(required));
+  req.auth.has(required)
+  ? next()
+  : next(either(I, sess => {
+    debug(`User "${sess.user}" is missing the "${required}"-permission`);
+    return missingPermission;
+  }, req.auth.session));

--- a/test/integration/server.test.js
+++ b/test/integration/server.test.js
@@ -64,11 +64,11 @@ describe('HTTP Server', () => {
       yield Future.try(_ => {
         expect(res.status).to.equal(200);
         expect(res.body).to.be.an('object');
-        expect(res.body).to.have.property('authorized', true);
-        expect(res.body).to.have.property('session', 'avaq');
-        expect(res.body).to.have.property('groups');
-        expect(res.body).to.have.property('permissions');
-        expect(res.body.groups).to.include.one.which.equals('@authorized');
+        expect(res.body).to.have.property('authenticated', true);
+        expect(res.body).to.have.property('session');
+        expect(res.body.session).to.be.an('object');
+        expect(res.body.session).to.have.property('user', 'avaq');
+        expect(res.body.session).to.have.property('groups');
       });
 
     }));
@@ -83,14 +83,11 @@ describe('HTTP Server', () => {
       yield Future.try(_ => {
         expect(res.status).to.equal(200);
         expect(res.body).to.be.an('object');
-        expect(res.body).to.have.property('authorized', false);
-        expect(res.body).to.have.property('session');
-        expect(res.body.session).to.be.an('object');
-        expect(res.body.session).to.have.property('name', 'MissingAuthorizationHeaderError');
-        expect(res.body.session).to.have.property('message');
-        expect(res.body).to.have.property('groups');
-        expect(res.body).to.have.property('permissions');
-        expect(res.body.groups).to.include.one.which.equals('@unauthorized');
+        expect(res.body).to.have.property('authenticated', false);
+        expect(res.body).to.have.property('reason');
+        expect(res.body.reason).to.be.an('object');
+        expect(res.body.reason).to.have.property('name', 'MissingAuthorizationHeaderError');
+        expect(res.body.reason).to.have.property('message');
       });
 
     }));


### PR DESCRIPTION
* Replace Authorized with Authenticated where it makes more sense
* Replace 403 with 401 where it makes more sense
* No longer provide the client with information about permissions
* Increase the usefulness of the errors in response to unauthorized requests