### PR TITLE
Use quotes in npm commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "setup": "npm run sanctuary-env && git config push.followTags true",
     "start": "node .",
     "test": "npm run clean && npm run lint && npm run test:coverage && npm run test:integration",
-    "test:integration": "NODE_ENV=test mocha test/integration/**/*.test.js",
-    "test:unit": "NODE_ENV=test mocha test/unit/**/*.test.js",
-    "test:coverage": "NODE_ENV=test istanbul cover --root src --report text --report html _mocha -- --reporter dot test/unit/**/*.test.js"
+    "test:integration": "NODE_ENV=test mocha 'test/integration/**/*.test.js'",
+    "test:unit": "NODE_ENV=test mocha 'test/unit/**/*.test.js'",
+    "test:coverage": "NODE_ENV=test istanbul cover --root src --report text --report html _mocha -- --reporter dot 'test/unit/**/*.test.js'"
   },
   "engines": {
     "node": "^4.0.0"


### PR DESCRIPTION
Some users might have old bash (or windows), which doesn't support globstar (and on mac `/bin/sh` is used by default for npm scripts even if different and newer bash is installed), so paths might not get expanded but mocha uses `node-glob` which has support for globstar, so if we pass args as a string to mocha it would handle expansion itself