### PR TITLE
Simplify 'lint:fix' execution

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "clean": "rimraf npm-debug.log coverage",
     "dev": "node-dev --no-notify --stack_trace_limit=100 .",
     "lint": "eslint src test config",
-    "lint:fix": "eslint --fix src test config",
+    "lint:fix": "npm run lint -- --fix",
     "precommit": "npm run lint && npm run test:unit && npm run test:integration && npm run check-security",
     "sanctuary-env": "node scripts/sanctuary-env",
     "setup": "npm run sanctuary-env && git config push.followTags true",


### PR DESCRIPTION
That way, you don't need to duplicate folder list in two places